### PR TITLE
SM-106 Update testnet

### DIFF
--- a/scripts/nodes.json
+++ b/scripts/nodes.json
@@ -13,19 +13,19 @@
   "relayNodes": [
     {
       "privateKey": "0x98bf857054c6aa0e92ddb6b98a3b63c603261be18b9ca7e882e7a95f297d3edb",
-      "publicEndpoint": "http://sylo-node-one-docker:28901/v1/public/metadata"
+      "publicEndpoint": "http://0.0.0.0:18901/v1/public/metadata"
     },
     {
       "privateKey": "0x17bb9893a53d58f4ea4f5d5f1248711d5e722be96c1f81ac562f815af078ecd0",
-      "publicEndpoint": "http://sylo-node-two-docker:28901/v1/public/metadata"
+      "publicEndpoint": "http://0.0.0.0:28901/v1/public/metadata"
     },
     {
       "privateKey": "0x2e445c0c320c158d9e3b40e8a419c7960dfe44225dc248eeb5b3bb7ac1a575e8",
-      "publicEndpoint": "http://sylo-node-three-docker:28901/v1/public/metadata"
+      "publicEndpoint": "http://0.0.0.0:38901/v1/public/metadata"
     },
     {
       "privateKey": "0x01a1b704b2efb0be843e9918b523da88baea76fcaf6e2b23ac1e3220b6b3523c",
-      "publicEndpoint": "http://sylo-node-four-docker:28901/v1/public/metadata"
+      "publicEndpoint": "http://0.0.0.0:48901/v1/public/metadata"
     }
   ]
 }


### PR DESCRIPTION
Minor PR to support https://github.com/futureversecom/sylo-protocol-sdk/pull/60. Includes an adjustment to the registry public endpoints in the ganache testnet to use different ports. This will better support running and connecting to the nodes locally.