### PR TITLE
SM-117 Seeker Oracle

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -43,11 +43,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: restore cache
-        uses: actions/cache@v3
+      - name: checkout code
+        uses: actions/checkout@v3
+
+      - name: Use Node.js 18.14.1
+        uses: actions/setup-node@v3
         with:
-          path: ./
-          key: repo-${{hashFiles('./')}}
+          node-version: 18.14.1
+          cache: 'yarn'
+
+      - name: yarn install
+        run: yarn
 
       - name: test contracts
         run: ITERATIONS=10000 npm test
@@ -66,11 +72,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: restore cache
-        uses: actions/cache@v3
+      - name: checkout code
+        uses: actions/checkout@v3
+
+      - name: Use Node.js 18.14.1
+        uses: actions/setup-node@v3
         with:
-          path: ./
-          key: repo-${{hashFiles('./')}}
+          node-version: 18.14.1
+          cache: 'yarn'
+
+      - name: yarn install
+        run: yarn
 
       - name: test contracts
         run: yarn coverage

--- a/common/contracts.ts
+++ b/common/contracts.ts
@@ -32,6 +32,7 @@ export type SyloContracts = {
   rewardsManager: factories.contracts.payments.ticketing.RewardsManager;
   directory: factories.contracts.staking.Directory;
   syloTicketing: factories.contracts.payments.SyloTicketing;
+  seekerPowerOracle: factories.contracts.SeekerPowerOracle;
   seekers: factories.contracts.mocks.TestSeekers;
   futurepassRegistrar: factories.contracts.mocks.TestFuturepassRegistrar;
 };

--- a/contracts/SeekerPowerOracle.sol
+++ b/contracts/SeekerPowerOracle.sol
@@ -49,7 +49,7 @@ contract SeekerPowerOracle is
   }
 
   function setSeekerPowerRestricted(uint256 seekerId, uint256 power) external {
-    if (msg.sender != this.owner() || msg.sender != oracle) {
+    if (msg.sender != this.owner() && msg.sender != oracle) {
       revert UnauthorizedSetSeekerCall();
     }
 
@@ -57,8 +57,8 @@ contract SeekerPowerOracle is
     emit SeekerPowerUpdated(seekerId, power);
   }
 
-  function setSeekerPower(uint256 seekerId, uint256 power, bytes calldata proof) external {
-    bytes memory proofMessage = getProofMessage((seekerId, power);
+  function registerSeekerPower(uint256 seekerId, uint256 power, bytes calldata proof) external {
+    bytes memory proofMessage = getProofMessage(seekerId, power);
     bytes32 ecdsaHash = ECDSA.toEthSignedMessageHash(proofMessage);
 
     if (ECDSA.recover(ecdsaHash, proof) != oracle) {
@@ -73,7 +73,7 @@ contract SeekerPowerOracle is
     return seekerPowers[seekerId];
   }
 
-  function getProofMessage(uint256 seekerId, uint256 power) external view returns (bytes memory) {
+  function getProofMessage(uint256 seekerId, uint256 power) public pure returns (bytes memory) {
     return abi.encodePacked(
       Strings.toString(seekerId),
       ":",

--- a/contracts/SeekerPowerOracle.sol
+++ b/contracts/SeekerPowerOracle.sol
@@ -13,71 +13,112 @@ import "./interfaces/ISeekerPowerOracle.sol";
  * a Seeker's power level via a restricted owner call. Seeker Power can also
  * be set by any account if the correct Oracle signature proof is provided.
  */
-contract SeekerPowerOracle is
-  ISeekerPowerOracle,
-  Initializable,
-  Ownable2StepUpgradeable
-{
-  /**
-   * @notice The oracle account. This contract accepts any attestations of
-   * Seeker power that have been signed by this account.
-   */
-  address public oracle;
+contract SeekerPowerOracle is ISeekerPowerOracle, Initializable, Ownable2StepUpgradeable {
+    /**
+     * @notice The oracle account. This contract accepts any attestations of
+     * Seeker power that have been signed by this account.
+     */
+    address public oracle;
 
-  /**
-   * @notice Tracks the set Seeker Power levels.
-   */
-  mapping(uint256 => uint256) public seekerPowers;
+    /**
+     * @notice Tracks nonce used when register the Seeker power to
+     * prevent signature re-use.
+     */
+    mapping(bytes32 => address) private proofNonces;
 
-  event SeekerPowerUpdated(
-    uint256 indexed seekerId,
-    uint256 indexed power
-  );
+    /**
+     * @notice Tracks the set Seeker Power levels.
+     */
+    mapping(uint256 => uint256) public seekerPowers;
 
-  function initialize(
-    address _oracle
-  ) external initializer {
-    Ownable2StepUpgradeable.__Ownable2Step_init();
+    event SeekerPowerUpdated(uint256 indexed seekerId, uint256 indexed power);
 
-    oracle = _oracle;
-  }
+    function initialize(address _oracle) external initializer {
+        Ownable2StepUpgradeable.__Ownable2Step_init();
 
-  error UnauthorizedSetSeekerCall();
-
-  function setOracle(address _oracle) external onlyOwner {
-    oracle = _oracle;
-  }
-
-  function setSeekerPowerRestricted(uint256 seekerId, uint256 power) external {
-    if (msg.sender != this.owner() && msg.sender != oracle) {
-      revert UnauthorizedSetSeekerCall();
+        oracle = _oracle;
     }
 
-    seekerPowers[seekerId] = power;
-    emit SeekerPowerUpdated(seekerId, power);
-  }
+    error UnauthorizedSetSeekerCall();
+    error NonceCannotBeReused();
 
-  function registerSeekerPower(uint256 seekerId, uint256 power, bytes calldata proof) external {
-    bytes memory proofMessage = getProofMessage(seekerId, power);
-    bytes32 ecdsaHash = ECDSA.toEthSignedMessageHash(proofMessage);
-
-    if (ECDSA.recover(ecdsaHash, proof) != oracle) {
-      revert UnauthorizedSetSeekerCall();
+    /**
+     * @notice Sets the oracle account.
+     * @param _oracle The oracle account.
+     */
+    function setOracle(address _oracle) external onlyOwner {
+        oracle = _oracle;
     }
 
-    seekerPowers[seekerId] = power;
-    emit SeekerPowerUpdated(seekerId, power);
-  }
+    /**
+     * @notice Registers a Seeker's power level. Only callable by the
+     * owner or the oracle account.
+     * @param seekerId The id of the Seeker.
+     * @param power The power level of the Seeker.
+     */
+    function registerSeekerPowerRestricted(uint256 seekerId, uint256 power) external {
+        if (msg.sender != this.owner() && msg.sender != oracle) {
+            revert UnauthorizedSetSeekerCall();
+        }
 
-  function getSeekerPower(uint256 seekerId) external view returns (uint256) {
-    return seekerPowers[seekerId];
-  }
+        seekerPowers[seekerId] = power;
+        emit SeekerPowerUpdated(seekerId, power);
+    }
 
-  function getProofMessage(uint256 seekerId, uint256 power) public pure returns (bytes memory) {
-    return abi.encodePacked(
-      Strings.toString(seekerId),
-      ":",
-      Strings.toString(power)
-    );
-  }
+    /**
+     * @notice Registers a Seeker's power level. Callable by any account
+     * but requires a proof signed by the oracle.
+     * @param seekerId The id of the Seeker.
+     * @param power The power level of the Seeker.
+     */
+    function registerSeekerPower(
+        uint256 seekerId,
+        uint256 power,
+        bytes32 nonce,
+        bytes calldata proof
+    ) external {
+        if (proofNonces[nonce] != address(0)) {
+            revert NonceCannotBeReused();
+        }
+
+        bytes memory proofMessage = getProofMessage(seekerId, power, nonce);
+        bytes32 ecdsaHash = ECDSA.toEthSignedMessageHash(proofMessage);
+
+        if (ECDSA.recover(ecdsaHash, proof) != oracle) {
+            revert UnauthorizedSetSeekerCall();
+        }
+
+        seekerPowers[seekerId] = power;
+        emit SeekerPowerUpdated(seekerId, power);
+
+        proofNonces[nonce] = oracle;
+    }
+
+    /**
+     * @notice Retrieves a Seeker's stored power level.
+     * @param seekerId The id of the Seeker.
+     */
+    function getSeekerPower(uint256 seekerId) external view returns (uint256) {
+        return seekerPowers[seekerId];
+    }
+
+    /**
+     * @notice Constructs a proof message for the oracle to sign.
+     * @param seekerId The id of the Seeker.
+     * @param power The power level of the Seeker.
+     */
+    function getProofMessage(
+        uint256 seekerId,
+        uint256 power,
+        bytes32 nonce
+    ) public pure returns (bytes memory) {
+        return
+            abi.encodePacked(
+                Strings.toString(seekerId),
+                ":",
+                Strings.toString(power),
+                ":",
+                Strings.toHexString(uint256(nonce), 32)
+            );
+    }
 }

--- a/contracts/SeekerPowerOracle.sol
+++ b/contracts/SeekerPowerOracle.sol
@@ -35,6 +35,7 @@ contract SeekerPowerOracle is ISeekerPowerOracle, Initializable, Ownable2StepUpg
 
     error UnauthorizedRegisterSeekerPowerCall();
     error NonceCannotBeReused();
+    error PowerCannotBeZero();
 
     function initialize(address _oracle) external initializer {
         Ownable2StepUpgradeable.__Ownable2Step_init();
@@ -61,6 +62,10 @@ contract SeekerPowerOracle is ISeekerPowerOracle, Initializable, Ownable2StepUpg
             revert UnauthorizedRegisterSeekerPowerCall();
         }
 
+        if (power == 0) {
+            revert PowerCannotBeZero();
+        }
+
         seekerPowers[seekerId] = power;
         emit SeekerPowerUpdated(seekerId, power);
     }
@@ -79,6 +84,10 @@ contract SeekerPowerOracle is ISeekerPowerOracle, Initializable, Ownable2StepUpg
     ) external {
         if (proofNonces[nonce] != address(0)) {
             revert NonceCannotBeReused();
+        }
+
+        if (power == 0) {
+            revert PowerCannotBeZero();
         }
 
         bytes memory proofMessage = getProofMessage(seekerId, power, nonce);

--- a/contracts/SeekerPowerOracle.sol
+++ b/contracts/SeekerPowerOracle.sol
@@ -27,7 +27,7 @@ contract SeekerPowerOracle is ISeekerPowerOracle, Initializable, Ownable2StepUpg
     mapping(bytes32 => address) private proofNonces;
 
     /**
-     * @notice Tracks the set Seeker Power levels.
+     * @notice Tracks the set of Seeker Power levels.
      */
     mapping(uint256 => uint256) public seekerPowers;
 

--- a/contracts/SeekerPowerOracle.sol
+++ b/contracts/SeekerPowerOracle.sol
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.18;
+
+import "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import "@openzeppelin/contracts/utils/Strings.sol";
+
+import "./interfaces/ISeekerPowerOracle.sol";
+
+/**
+ * @notice Acts as a source of information for Seeker Powers. Allows setting
+ * a Seeker's power level via a restricted owner call. Seeker Power can also
+ * be set by any account if the correct Oracle signature proof is provided.
+ */
+contract SeekerPowerOracle is
+  ISeekerPowerOracle,
+  Initializable,
+  Ownable2StepUpgradeable
+{
+  /**
+   * @notice The oracle account. This contract accepts any attestations of
+   * Seeker power that have been signed by this account.
+   */
+  address public oracle;
+
+  /**
+   * @notice Tracks the set Seeker Power levels.
+   */
+  mapping(uint256 => uint256) public seekerPowers;
+
+  event SeekerPowerUpdated(
+    uint256 indexed seekerId,
+    uint256 indexed power
+  );
+
+  function initialize(
+    address _oracle
+  ) external initializer {
+    Ownable2StepUpgradeable.__Ownable2Step_init();
+
+    oracle = _oracle;
+  }
+
+  error UnauthorizedSetSeekerCall();
+
+  function setOracle(address _oracle) external onlyOwner {
+    oracle = _oracle;
+  }
+
+  function setSeekerPowerRestricted(uint256 seekerId, uint256 power) external {
+    if (msg.sender != this.owner() || msg.sender != oracle) {
+      revert UnauthorizedSetSeekerCall();
+    }
+
+    seekerPowers[seekerId] = power;
+    emit SeekerPowerUpdated(seekerId, power);
+  }
+
+  function setSeekerPower(uint256 seekerId, uint256 power, bytes calldata proof) external {
+    bytes memory proofMessage = getProofMessage((seekerId, power);
+    bytes32 ecdsaHash = ECDSA.toEthSignedMessageHash(proofMessage);
+
+    if (ECDSA.recover(ecdsaHash, proof) != oracle) {
+      revert UnauthorizedSetSeekerCall();
+    }
+
+    seekerPowers[seekerId] = power;
+    emit SeekerPowerUpdated(seekerId, power);
+  }
+
+  function getSeekerPower(uint256 seekerId) external view returns (uint256) {
+    return seekerPowers[seekerId];
+  }
+
+  function getProofMessage(uint256 seekerId, uint256 power) external view returns (bytes memory) {
+    return abi.encodePacked(
+      Strings.toString(seekerId),
+      ":",
+      Strings.toString(power)
+    );
+  }
+}

--- a/contracts/interfaces/IFuturePassRegistrar.sol
+++ b/contracts/interfaces/IFuturePassRegistrar.sol
@@ -3,5 +3,6 @@ pragma solidity ^0.8.18;
 
 interface IFuturePassRegistrar {
     function futurepassOf(address owner) external view returns (address);
+
     function create(address owner) external returns (address);
 }

--- a/contracts/interfaces/ISeekerPowerOracle.sol
+++ b/contracts/interfaces/ISeekerPowerOracle.sol
@@ -2,13 +2,22 @@
 pragma solidity ^0.8.18;
 
 interface ISeekerPowerOracle {
-  function setOracle(address oracle) external;
+    function setOracle(address oracle) external;
 
-  function setSeekerPowerRestricted(uint256 seekerId, uint256 power) external;
+    function registerSeekerPowerRestricted(uint256 seekerId, uint256 power) external;
 
-  function registerSeekerPower(uint256 seekerId, uint256 power, bytes calldata proof) external;
+    function registerSeekerPower(
+        uint256 seekerId,
+        uint256 power,
+        bytes32 nonce,
+        bytes calldata proof
+    ) external;
 
-  function getSeekerPower(uint256 seekerId) external view returns (uint256);
+    function getSeekerPower(uint256 seekerId) external view returns (uint256);
 
-  function getProofMessage(uint256 seekerId, uint256 power) external pure returns (bytes memory);
+    function getProofMessage(
+        uint256 seekerId,
+        uint256 power,
+        bytes32 nonce
+    ) external pure returns (bytes memory);
 }

--- a/contracts/interfaces/ISeekerPowerOracle.sol
+++ b/contracts/interfaces/ISeekerPowerOracle.sol
@@ -6,7 +6,9 @@ interface ISeekerPowerOracle {
 
   function setSeekerPowerRestricted(uint256 seekerId, uint256 power) external;
 
-  function setSeekerPower(uint256 seekerId, uint256 power, bytes calldata proof) external;
+  function registerSeekerPower(uint256 seekerId, uint256 power, bytes calldata proof) external;
 
-  function getProofMessage(uint256 seekerId, uint256 power) external view returns (bytes memory);
+  function getSeekerPower(uint256 seekerId) external view returns (uint256);
+
+  function getProofMessage(uint256 seekerId, uint256 power) external pure returns (bytes memory);
 }

--- a/contracts/interfaces/ISeekerPowerOracle.sol
+++ b/contracts/interfaces/ISeekerPowerOracle.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.18;
+
+interface ISeekerPowerOracle {
+  function setOracle(address oracle) external;
+
+  function setSeekerPowerRestricted(uint256 seekerId, uint256 power) external;
+
+  function setSeekerPower(uint256 seekerId, uint256 power, bytes calldata proof) external;
+
+  function getProofMessage(uint256 seekerId, uint256 power) external view returns (bytes memory);
+}

--- a/contracts/mocks/TestFuturepassRegistrar.sol
+++ b/contracts/mocks/TestFuturepassRegistrar.sol
@@ -2,16 +2,16 @@
 pragma solidity ^0.8.18;
 
 contract TestFuturepassRegistrar {
-  mapping(address => address) registrations;
+    mapping(address => address) registrations;
 
-  function futurepassOf(address owner) external view returns (address) {
-    return registrations[owner];
-  }
+    function futurepassOf(address owner) external view returns (address) {
+        return registrations[owner];
+    }
 
-  function create(address owner) external returns (address) {
-    // ticketing contract does not actually care about futurepass
-    // address value, just needs to be non-zero
-    registrations[owner] = owner;
-    return owner;
-  }
+    function create(address owner) external returns (address) {
+        // ticketing contract does not actually care about futurepass
+        // address value, just needs to be non-zero
+        registrations[owner] = owner;
+        return owner;
+    }
 }

--- a/test/seekerOracle.test.ts
+++ b/test/seekerOracle.test.ts
@@ -1,0 +1,193 @@
+import { ethers } from 'hardhat';
+import { Signer } from 'ethers';
+import { SyloToken } from '../typechain-types';
+import utils from './utils';
+import { SyloContracts } from '../common/contracts';
+import { expect } from 'chai';
+
+describe('Seeker Power Oracle', () => {
+  let accounts: Signer[];
+  let deployer: string;
+
+  let token: SyloToken;
+  let contracts: SyloContracts;
+
+  before(async () => {
+    accounts = await ethers.getSigners();
+    deployer = await accounts[0].getAddress();
+
+    const Token = await ethers.getContractFactory('SyloToken');
+    token = await Token.deploy();
+  });
+
+  beforeEach(async () => {
+    contracts = await utils.initializeContracts(deployer, token);
+  });
+
+  it('can set oracle with owner', async () => {
+    const oracle = await accounts[1].getAddress();
+    await contracts.seekerPowerOracle.setOracle(oracle);
+
+    const _oracle = await contracts.seekerPowerOracle.oracle();
+
+    expect(_oracle).to.equal(oracle);
+  });
+
+  it('can set seeker power with oracle', async () => {
+    const oracle = await accounts[1].getAddress();
+    await contracts.seekerPowerOracle.setOracle(oracle);
+
+    const seekerId = 5;
+
+    // check power of seeker id 5
+    const zeroPower = await contracts.seekerPowerOracle.seekerPowers(seekerId);
+    expect(zeroPower).to.equal(0);
+
+    const seekerPower = 111;
+
+    // update with oracle
+    await contracts.seekerPowerOracle
+      .connect(accounts[1])
+      .setSeekerPowerRestricted(seekerId, seekerPower);
+
+    const updatedPower = await contracts.seekerPowerOracle.seekerPowers(
+      seekerId,
+    );
+    expect(updatedPower).to.equal(seekerPower);
+  });
+
+  it('can set seeker power with owner', async () => {
+    const seekerId = 5;
+
+    // check power of seeker id 5
+    const zeroPower = await contracts.seekerPowerOracle.seekerPowers(seekerId);
+    expect(zeroPower).to.equal(0);
+
+    const seekerPower = 111;
+
+    // update with oracle
+    await contracts.seekerPowerOracle.setSeekerPowerRestricted(
+      seekerId,
+      seekerPower,
+    );
+
+    const updatedPower = await contracts.seekerPowerOracle.seekerPowers(
+      seekerId,
+    );
+    expect(updatedPower).to.equal(seekerPower);
+  });
+
+  it('only allows setSeekerPowerRestricted to be called by owner or oracle', async () => {
+    await expect(
+      contracts.seekerPowerOracle
+        .connect(accounts[2]) // unauthorized caller
+        .setSeekerPowerRestricted(1, 2),
+    ).to.be.revertedWithCustomError(
+      contracts.seekerPowerOracle,
+      'UnauthorizedSetSeekerCall',
+    );
+  });
+
+  it('can set seeker power with proof', async () => {
+    const oracle = await accounts[1].getAddress();
+    await contracts.seekerPowerOracle.setOracle(oracle);
+
+    const seekerId = 111;
+    const seekerPower = 222;
+
+    const proofMessage = await contracts.seekerPowerOracle.getProofMessage(
+      seekerId,
+      seekerPower,
+    );
+
+    const proof = await accounts[1].signMessage(
+      Buffer.from(proofMessage.slice(2), 'hex'),
+    );
+
+    await contracts.seekerPowerOracle
+      .connect(accounts[2])
+      .registerSeekerPower(seekerId, seekerPower, proof);
+
+    const updatedPower = await contracts.seekerPowerOracle.seekerPowers(
+      seekerId,
+    );
+    expect(updatedPower).to.equal(seekerPower);
+  });
+
+  it('reverts when setting seeker power with invalid proof', async () => {
+    const oracle = await accounts[1].getAddress();
+    await contracts.seekerPowerOracle.setOracle(oracle);
+
+    const seekerId = 111;
+    const seekerPower = 222;
+
+    const proofMessage = await contracts.seekerPowerOracle.getProofMessage(
+      seekerId,
+      seekerPower,
+    );
+
+    // sign with non-oracle account
+    const proof = await accounts[2].signMessage(
+      Buffer.from(proofMessage.slice(2), 'hex'),
+    );
+
+    await expect(
+      contracts.seekerPowerOracle
+        .connect(accounts[3])
+        .registerSeekerPower(seekerId, seekerPower, proof),
+    ).to.be.revertedWithCustomError(
+      contracts.seekerPowerOracle,
+      'UnauthorizedSetSeekerCall',
+    );
+  });
+
+  it('can update multiple seeker powers', async () => {
+    for (let i = 1; i < 11; i++) {
+      const seekerId = i;
+      const seekerPower = i * 1111;
+
+      const proofMessage = await contracts.seekerPowerOracle.getProofMessage(
+        seekerId,
+        seekerPower,
+      );
+
+      const proof = await accounts[0].signMessage(
+        Buffer.from(proofMessage.slice(2), 'hex'),
+      );
+
+      await contracts.seekerPowerOracle
+        .connect(accounts[i])
+        .registerSeekerPower(seekerId, seekerPower, proof);
+
+      const updatedPower = await contracts.seekerPowerOracle.seekerPowers(
+        seekerId,
+      );
+      expect(updatedPower).to.equal(seekerPower);
+    }
+  });
+
+  it('can update the same seeker power multiple times', async () => {
+    for (let i = 0; i < 5; i++) {
+      const seekerId = 1;
+      const seekerPower = i * 1111;
+
+      const proofMessage = await contracts.seekerPowerOracle.getProofMessage(
+        seekerId,
+        seekerPower,
+      );
+
+      const proof = await accounts[0].signMessage(
+        Buffer.from(proofMessage.slice(2), 'hex'),
+      );
+
+      await contracts.seekerPowerOracle
+        .connect(accounts[1])
+        .registerSeekerPower(seekerId, seekerPower, proof);
+
+      const updatedPower = await contracts.seekerPowerOracle.seekerPowers(
+        seekerId,
+      );
+      expect(updatedPower).to.equal(seekerPower);
+    }
+  });
+});

--- a/test/seekerOracle.test.ts
+++ b/test/seekerOracle.test.ts
@@ -25,6 +25,12 @@ describe('Seeker Power Oracle', () => {
     contracts = await utils.initializeContracts(deployer, token);
   });
 
+  it('seeker power oracle cannot be initialized twice', async () => {
+    await expect(
+      contracts.seekerPowerOracle.initialize(deployer),
+    ).to.be.revertedWith('Initializable: contract is already initialized');
+  });
+
   it('can set oracle with owner', async () => {
     const oracle = await accounts[1].getAddress();
     await contracts.seekerPowerOracle.setOracle(oracle);
@@ -32,6 +38,12 @@ describe('Seeker Power Oracle', () => {
     const _oracle = await contracts.seekerPowerOracle.oracle();
 
     expect(_oracle).to.equal(oracle);
+  });
+
+  it('reverts with setting oracle with non-owner', async () => {
+    await expect(
+      contracts.seekerPowerOracle.connect(accounts[3]).setOracle(deployer),
+    ).to.be.revertedWith('Ownable: caller is not the owner');
   });
 
   it('can set seeker power with oracle', async () => {

--- a/test/seekerOracle.test.ts
+++ b/test/seekerOracle.test.ts
@@ -94,14 +94,14 @@ describe('Seeker Power Oracle', () => {
     expect(updatedPower).to.equal(seekerPower);
   });
 
-  it('only allows registerSeekerPowerRestricted to be called by owner or oracle', async () => {
+  it('only allows registerSeekerPowerRestricted to be called by the oracle', async () => {
     await expect(
       contracts.seekerPowerOracle
         .connect(accounts[2]) // unauthorized caller
         .registerSeekerPowerRestricted(1, 2),
     ).to.be.revertedWithCustomError(
       contracts.seekerPowerOracle,
-      'UnauthorizedSetSeekerCall',
+      'UnauthorizedRegisterSeekerPowerCall',
     );
   });
 
@@ -161,7 +161,7 @@ describe('Seeker Power Oracle', () => {
       ),
     ).to.be.revertedWithCustomError(
       contracts.seekerPowerOracle,
-      'UnauthorizedSetSeekerCall',
+      'UnauthorizedRegisterSeekerPowerCall',
     );
 
     const validProof = await accounts[1].signMessage(

--- a/test/seekerOracle.test.ts
+++ b/test/seekerOracle.test.ts
@@ -188,6 +188,39 @@ describe('Seeker Power Oracle', () => {
     );
   });
 
+  it('can not set seeker power to 0', async () => {
+    const seekerId = 111;
+
+    await expect(
+      contracts.seekerPowerOracle.registerSeekerPowerRestricted(seekerId, 0),
+    ).to.be.revertedWithCustomError(
+      contracts.seekerPowerOracle,
+      'PowerCannotBeZero',
+    );
+
+    const seekerPower = 0;
+    const nonce = randomBytes(32);
+
+    const proofMessage = await contracts.seekerPowerOracle.getProofMessage(
+      seekerId,
+      seekerPower,
+      nonce,
+    );
+
+    const proof = await accounts[1].signMessage(
+      Buffer.from(proofMessage.slice(2), 'hex'),
+    );
+
+    await expect(
+      contracts.seekerPowerOracle
+        .connect(accounts[2])
+        .registerSeekerPower(seekerId, seekerPower, nonce, proof),
+    ).to.be.revertedWithCustomError(
+      contracts.seekerPowerOracle,
+      'PowerCannotBeZero',
+    );
+  });
+
   it('can update multiple seeker powers', async () => {
     for (let i = 1; i < 11; i++) {
       const seekerId = i;
@@ -216,7 +249,7 @@ describe('Seeker Power Oracle', () => {
   });
 
   it('can update the same seeker power multiple times', async () => {
-    for (let i = 0; i < 5; i++) {
+    for (let i = 1; i < 6; i++) {
       const seekerId = 1;
       const seekerPower = i * 1111;
       const nonce = randomBytes(32);

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -16,7 +16,7 @@ type Options = {
   epochDuration?: number;
   minimumStakeProportion?: number;
   unlockDuration?: number;
-  oracle?: string;
+  seekerPowerOracleAccount?: string;
 };
 
 const initializeContracts = async function (
@@ -38,7 +38,7 @@ const initializeContracts = async function (
 
   const minimumStakeProportion = opts.minimumStakeProportion ?? 2000;
 
-  const oracle = opts.oracle ?? deployer;
+  const seekerPowerOracleAccount = opts.seekerPowerOracleAccount ?? deployer;
 
   const tokenAddress = await syloToken.getAddress();
 
@@ -126,7 +126,9 @@ const initializeContracts = async function (
     { from: deployer },
   );
   await authorizedAccounts.initialize({ from: deployer });
-  await seekerPowerOracle.initialize(oracle, { from: deployer });
+  await seekerPowerOracle.initialize(seekerPowerOracleAccount, {
+    from: deployer,
+  });
 
   const TicketingFactory = await ethers.getContractFactory('SyloTicketing');
   const syloTicketing = await TicketingFactory.deploy();

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -16,6 +16,7 @@ type Options = {
   epochDuration?: number;
   minimumStakeProportion?: number;
   unlockDuration?: number;
+  oracle?: string;
 };
 
 const initializeContracts = async function (
@@ -36,6 +37,8 @@ const initializeContracts = async function (
   const unlockDuration = opts.unlockDuration ?? 10;
 
   const minimumStakeProportion = opts.minimumStakeProportion ?? 2000;
+
+  const oracle = opts.oracle ?? deployer;
 
   const tokenAddress = await syloToken.getAddress();
 
@@ -87,6 +90,11 @@ const initializeContracts = async function (
   );
   const authorizedAccounts = await AuthorizedAccountFactory.deploy();
 
+  const SeekerPowerOracleFactory = await ethers.getContractFactory(
+    'SeekerPowerOracle',
+  );
+  const seekerPowerOracle = await SeekerPowerOracleFactory.deploy();
+
   await stakingManager.initialize(
     tokenAddress,
     await rewardsManager.getAddress(),
@@ -118,6 +126,7 @@ const initializeContracts = async function (
     { from: deployer },
   );
   await authorizedAccounts.initialize({ from: deployer });
+  await seekerPowerOracle.initialize(oracle, { from: deployer });
 
   const TicketingFactory = await ethers.getContractFactory('SyloTicketing');
   const syloTicketing = await TicketingFactory.deploy();
@@ -157,6 +166,7 @@ const initializeContracts = async function (
     directory,
     syloTicketing,
     seekers,
+    seekerPowerOracle,
     futurepassRegistrar,
   };
 };


### PR DESCRIPTION
This PR adds the interface for the Seeker Oracle contract, as well as a basic implementation. The Seeker Oracle works by keeping a record of a "oracle" account, and also a mapping of Seeker Ids to Seeker Power levels. The oracle account to set the a Seeker's power level mapping by calling the method `setSeekerPowerRestricted`. Only the oracle account and the owner account (deployer) are allowed to call this method.

There is also an additional way to set the seeker's power level by calling the unrestricted method `registerSeekerPower`. The register method takes an additional parameter, a `proof` message. The proof is a specific message that has been signed by the `oracle` account. The structure of the message is as follows:
`${seekerId}:${seekerPower}`
The register function only allows proofs that have been signed by the `oracle` account.

This approach allows us to build an API that holds the `oracle` account private key, and provides an API method to acquire the proof for a given Seeker Id. The API has knowledge of all Seeker power levels (and acts as the source of truth outside of the contracts).