### PR TITLE
SM-386

### DIFF
--- a/contracts/payments/IRewardsManager.sol
+++ b/contracts/payments/IRewardsManager.sol
@@ -9,6 +9,20 @@ interface IRewardsManager {
         uint256[] calldata cycles
     ) external view returns (uint256[] memory);
 
+    function getClaim(address node, address user, uint256 cycle) external view returns (uint256);
+
+    function getUnclaimedReward(
+        address node,
+        address user,
+        uint256 cycle
+    ) external view returns (uint256);
+
+    function getUnclaimedRewards(
+        address node,
+        address user,
+        uint256[] calldata cycles
+    ) external view returns (uint256[] memory);
+
     function getUnclaimedNodeCommission(address node) external view returns (uint256);
 
     function incrementRewardPool(address node, uint256 amount) external;

--- a/contracts/payments/RewardsManager.sol
+++ b/contracts/payments/RewardsManager.sol
@@ -136,14 +136,6 @@ contract RewardsManager is IRewardsManager, Initializable, AccessControl {
         return _getUnclaimedReward(node, user, cycle);
     }
 
-    function _getUnclaimedReward(address node, address user, uint256 cycle) internal view returns (uint256) {
-        if (claims[node][user][cycle]) {
-            return 0;
-        }
-
-        return _getClaim(node, user, cycle);
-    }
-
     function getUnclaimedRewards(address node, address user, uint256[] calldata cycles) external view returns (uint256[] memory) {
         uint256 [] memory unclaimedRewards = new uint256[](cycles.length);
 
@@ -152,6 +144,14 @@ contract RewardsManager is IRewardsManager, Initializable, AccessControl {
         }
 
         return unclaimedRewards;
+    }
+
+    function _getUnclaimedReward(address node, address user, uint256 cycle) internal view returns (uint256) {
+        if (claims[node][user][cycle]) {
+            return 0;
+        }
+
+        return _getClaim(node, user, cycle);
     }
 
     function getClaim(address node, address user, uint256 cycle) external view returns (uint256) {

--- a/test/paymets/rewardsManager.test.ts
+++ b/test/paymets/rewardsManager.test.ts
@@ -294,6 +294,14 @@ describe('Rewards Manager', () => {
       await setTimeSinceStart(1000);
 
       await testClaim(node1.getAddress(), user, 1, rewardAmount);
+
+      const unclaimedReward = await rewardsManager.getUnclaimedReward(
+        node1.getAddress(),
+        user.address,
+        1,
+      );
+
+      expect(unclaimedReward).to.equal(0);
     });
 
     it('can claim reward over multiple cycles', async () => {

--- a/test/paymets/rewardsManager.test.ts
+++ b/test/paymets/rewardsManager.test.ts
@@ -244,6 +244,9 @@ describe('Rewards Manager', () => {
       'function getUnclaimedNodeCommission(address node) external view returns (uint256)',
       'function incrementRewardPool(address node, uint256 amount) external',
       'function claim(address node, uint256 cycle) external',
+      'function getClaim(address node, address user, uint256 cycle) external view returns (uint256)',
+      'function getUnclaimedReward(address node, address user, uint256 cycle) external view returns (uint256)',
+      'function getUnclaimedRewards(address node, address user, uint256[] cycles) external view returns (uint256[])',
     ];
 
     const interfaceId = getInterfaceId(abi);
@@ -308,6 +311,16 @@ describe('Rewards Manager', () => {
         await setTimeSinceStart(cycle * 1000);
       }
 
+      const unclaimedRewards = await rewardsManager.getUnclaimedRewards(
+        node1.getAddress(),
+        user.getAddress(),
+        cycles,
+      );
+
+      for (const [i, r] of unclaimedRewards.entries()) {
+        expect(r).to.be.eq(BigInt(i + 1) * rewardAmount);
+      }
+
       for (const cycle of cycles) {
         await testClaim(
           node1.getAddress(),
@@ -363,7 +376,15 @@ describe('Rewards Manager', () => {
 
       await setTimeSinceStart(1000);
 
-      await testClaim(node1.getAddress(), node1, 1, rewardAmount / 2n);
+      const balance = await contracts.syloToken.balanceOf(node1.getAddress());
+
+      await rewardsManager.connect(node1).claim(node1.getAddress(), 1);
+
+      const balanceAfter = await contracts.syloToken.balanceOf(
+        node1.getAddress(),
+      );
+
+      expect(balanceAfter).to.equal(balance + rewardAmount / 2n);
     });
 
     it('can claim as node and stakee', async () => {
@@ -381,7 +402,15 @@ describe('Rewards Manager', () => {
 
       await setTimeSinceStart(1000);
 
-      await testClaim(node1.getAddress(), node1, 1, rewardAmount);
+      const balance = await contracts.syloToken.balanceOf(node1.getAddress());
+
+      await rewardsManager.connect(node1).claim(node1.getAddress(), 1);
+
+      const balanceAfter = await contracts.syloToken.balanceOf(
+        node1.getAddress(),
+      );
+
+      expect(balanceAfter).to.equal(balance + rewardAmount);
     });
 
     it('claim is distributed between nodes and stakers', async () => {
@@ -501,8 +530,14 @@ describe('Rewards Manager', () => {
     const balance = await contracts.syloToken.balanceOf(user);
 
     const claim = await rewardsManager.getClaim(node, user.getAddress(), cycle);
-
     expect(claim).to.equal(expectedIncrease);
+
+    const unclaimed = await rewardsManager.getUnclaimedReward(
+      node,
+      user.getAddress(),
+      cycle,
+    );
+    expect(unclaimed).to.equal(expectedIncrease);
 
     await rewardsManager.connect(user).claim(node, cycle);
 


### PR DESCRIPTION
This is a small PR that adds the following methods to the `RewardsManager` contract.

- `getClaim`
- `getUnclaimedReward`
- `getUnclaimedReward`

These methods make it easier for clients to determine if a user has an unclaimed reward for a given cycle.